### PR TITLE
pyvw dependency fix

### DIFF
--- a/from_mwt_ds/DataScience/setup.py
+++ b/from_mwt_ds/DataScience/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 MAJOR               = 0
 MINOR               = 1
-MICRO               = 6
+MICRO               = 7
 VERSION             = f"{MAJOR}.{MINOR}.{MICRO}"
 
 with open("README.md", "r") as f:

--- a/from_mwt_ds/DataScience/vw_executor/vw.py
+++ b/from_mwt_ds/DataScience/vw_executor/vw.py
@@ -63,6 +63,7 @@ class _VwBin(_VwCore):
 
 def _run_pyvw(args: str) -> Iterable[str]:
     from vowpalwabbit import pyvw
+    
     with pyvw.vw(args, enable_logging=True) as execution:
         return execution.get_log()
 

--- a/from_mwt_ds/DataScience/vw_executor/vw.py
+++ b/from_mwt_ds/DataScience/vw_executor/vw.py
@@ -23,7 +23,7 @@ def _save(txt: Union[str, Iterable[str]], path: Path) -> None:
         if isinstance(txt, str):
             f.write(txt)
         else:
-            f.writelines(txt)
+            f.writelines(map(lambda l: f'{l}\n', txt))
 
 
 class ExecutionStatus(enum.Enum):
@@ -63,9 +63,9 @@ class _VwBin(_VwCore):
 
 def _run_pyvw(args: str) -> Iterable[str]:
     from vowpalwabbit import pyvw
-    
-    with pyvw.vw(args, enable_logging=True) as execution:
-        return execution.get_log()
+    execution = pyvw.vw(args, enable_logging=True)
+    execution.finish()
+    return [l.rstrip() for l in execution.get_log()]
 
 
 class _VwPy(_VwCore):


### PR DESCRIPTION
Fixing pyvw dependency due to: https://github.com/VowpalWabbit/vowpal_wabbit/issues/3863
1) explicit call of Workspace.finish() before getting logs
2) rstripping log lines and adding '\n' explicitly in order to handle '\n' removal