### PR TITLE
pyvw.vw -> pyvw.Workspace

### DIFF
--- a/from_mwt_ds/DataScience/setup.py
+++ b/from_mwt_ds/DataScience/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 MAJOR               = 0
 MINOR               = 3
-MICRO               = 1
+MICRO               = 2
 VERSION             = f"{MAJOR}.{MINOR}.{MICRO}"
 
 with open("README.md", "r") as f:

--- a/from_mwt_ds/DataScience/vw_executor/vw.py
+++ b/from_mwt_ds/DataScience/vw_executor/vw.py
@@ -77,7 +77,7 @@ def _run_pyvw(args: str, filename=None) -> Iterable[str]:
 
     from vowpalwabbit import pyvw
     try:
-        execution = pyvw.vw(args, enable_logging=True)
+        execution = pyvw.Workspace(args, enable_logging=True)
     except Exception as e:
         if filename is not None:
             stderr_temp = filename.parent / (filename.name + '.pending')


### PR DESCRIPTION
Switching to pyvw.Workspace (since pyvw.vw is deprecated)