### PR TITLE
fix: remove unnecessary Pool(1) wrapper in _VwPy.run()

### DIFF
--- a/from_mwt_ds/DataScience/vw_executor/vw.py
+++ b/from_mwt_ds/DataScience/vw_executor/vw.py
@@ -103,8 +103,11 @@ class _VwPy(_VwCore):
         super().__init__(None)
 
     def run(self, args: str, filename=None) -> Iterable[str]:
-        from multiprocessing import Pool
-        with Pool(1) as p:
+        # Use spawn context to avoid fork issues with pybind11
+        # Each VW call runs in its own subprocess for isolation
+        import multiprocessing
+        ctx = multiprocessing.get_context('spawn')
+        with ctx.Pool(1) as p:
             return p.apply(_run_pyvw, [args], {"filename": filename})
 
 def symlink(source:Path, link_name:Path):


### PR DESCRIPTION
## Summary

Use `spawn` context for the `Pool(1)` in `_VwPy.run()` to enable compatibility with pybind11 bindings.

## Problem

The `Pool(1)` wrapper is required because **VW is not thread-safe internally** - each VW call must run in its own subprocess for isolation.

However, the default fork-based Pool doesn't work with pybind11 bindings because pybind11 modules don't survive `fork()` cleanly, causing segfaults or hangs.

## Solution

Use `multiprocessing.get_context('spawn')` to create a spawn-based Pool:

```python
def run(self, args: str, filename=None) -> Iterable[str]:
    # Use spawn context to avoid fork issues with pybind11
    import multiprocessing
    ctx = multiprocessing.get_context('spawn')
    with ctx.Pool(1) as p:
        return p.apply(_run_pyvw, [args], {"filename": filename})
```

The spawn context starts fresh Python interpreters instead of forking, which is compatible with pybind11.

## Testing

Verified locally that vw_executor works with pybind11-based vowpalwabbit bindings when called from Python scripts.

## Note

Code that calls vw_executor at module import time (before `if __name__ == '__main__'` guard) may still have issues because spawn needs to re-import the main module in child processes. Such code should be restructured to defer VW execution to runtime.

Fixes #80